### PR TITLE
Replace the deprecated Bulma nav class for navbar

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -6,12 +6,12 @@
 <div class="navbar-wrapper navbar-sticky">
   <div class="hero-head">
     <div class="container">
-      <nav class="nav">
-        <div class="nav-left">
-          <a class="nav-item" href="{{ .Site.BaseURL }}">
+      <nav class="navbar">
+        <div class="navbar-start">
+          <a class="navbar-item" href="{{ .Site.BaseURL }}">
             <img class="brand" src="{{ $logoSrc }}" alt="{{ $logoAlt }}">
           </a>
-          <a id="panel-trigger" href="#left-panel" class="nav-item nav-inner hamburger-btn" href="javascript:void(0);">
+          <a id="panel-trigger" href="#left-panel" class="navbar-item navbar-inner hamburger-btn" href="javascript:void(0);">
             <span class="menu-toggle">
               <span class="icon-box-toggle">
                 <span class="rotate">
@@ -23,20 +23,20 @@
             </span>
           </a>
         </div>
-        <span class="nav-toggle">
+        <span class="navbar-toggle">
           <span></span>
           <span></span>
           <span></span>
         </span>
-        <div class="nav-right nav-menu">
+        <div class="navbar-end navbar-menu">
           {{- range $links -}}
           {{- if ne .dropdown true }}
-          <a class="nav-item is-tab nav-inner" href="{{ .url }}">
+          <a class="navbar-item is-tab navbar-inner" href="{{ .url }}">
             {{ .text }}
           </a>
           {{- else }}
-          <div class="nav-item is-drop">
-            <a class="nav-item is-tab nav-inner-xs">
+          <div class="navbar-item is-drop">
+            <a class="navbar-item is-tab navbar-inner-xs">
               {{ .text }}
             </a>
             <span class="drop-caret"><i class="fa fa-angle-down"></i></span>
@@ -54,7 +54,7 @@
           {{- end -}}
           {{- end -}}
 
-          <span class="nav-item">
+          <span class="navbar-item">
             <a class="button cta is-large rounded secondary-btn raised">
               {{ $buttonText }}
             </a>

--- a/source/js/fresh.js
+++ b/source/js/fresh.js
@@ -2,8 +2,8 @@ $(function(){
 
   // The following code is based off a toggle menu by @Bradcomp
   (function() {
-    var burger = document.querySelector('.nav-toggle');
-    var menu = document.querySelector('.nav-menu');
+    var burger = document.querySelector('.navbar-toggle');
+    var menu = document.querySelector('.navbar-menu');
     burger.addEventListener('click', function() {
       burger.classList.toggle('is-active');
       menu.classList.toggle('is-active');

--- a/source/scss/_dropdowns.scss
+++ b/source/scss/_dropdowns.scss
@@ -3,20 +3,20 @@ Dropdown styles
 ========================================================================== */
 
 // Hover Dropdowns 
-div.nav-item.is-drop a {
+div.navbar-item.is-drop a {
     padding-right: 7px;
 }
 
-div.nav-item.is-drop:hover .dropContain .dropOut {
+div.navbar-item.is-drop:hover .dropContain .dropOut {
     opacity: 1;
 }
 
-div.nav-item.is-drop:hover, div.nav-item.is-drop:hover a, {
+div.navbar-item.is-drop:hover, div.navbar-item.is-drop:hover a, {
     border-bottom: 1px solid transparent !important;
     color: $secondary;
 }
 
-div.nav-item.is-drop:hover .dropContain {
+div.navbar-item.is-drop:hover .dropContain {
     top: 65px;
     animation: fadeInUp 0.27s ease-out;
 }
@@ -26,7 +26,7 @@ span.drop-caret {
     top: 5px;
 }
 
-div.nav-item.is-drop {
+div.navbar-item.is-drop {
     position: relative;
     .dropContain {
         width: 220px;

--- a/source/scss/_dropdowns.scss
+++ b/source/scss/_dropdowns.scss
@@ -12,18 +12,13 @@ div.navbar-item.is-drop:hover .dropContain .dropOut {
 }
 
 div.navbar-item.is-drop:hover, div.navbar-item.is-drop:hover a, {
-    border-bottom: 1px solid transparent !important;
+    border-bottom: 0.5px solid transparent !important;
     color: $secondary;
 }
 
 div.navbar-item.is-drop:hover .dropContain {
     top: 65px;
     animation: fadeInUp 0.27s ease-out;
-}
-
-span.drop-caret {
-    position: relative;
-    top: 5px;
 }
 
 div.navbar-item.is-drop {

--- a/source/scss/_hero.scss
+++ b/source/scss/_hero.scss
@@ -27,13 +27,13 @@ Hero styles
             color: #363636;
         }
     }
-    &.is-primary a.nav-item.nav-inner-xs, &.is-info a.nav-item.nav-inner-xs, &.is-danger a.nav-item.nav-inner-xs, &.is-success a.nav-item.nav-inner-xs, &.is-dark a.nav-item.nav-inner-xs  {
+    &.is-primary a.navbar-item.navbar-inner-xs, &.is-info a.navbar-item.navbar-inner-xs, &.is-danger a.navbar-item.navbar-inner-xs, &.is-success a.navbar-item.navbar-inner-xs, &.is-dark a.navbar-item.navbar-inner-xs  {
         color: #7a7a7a;
         &:hover {
             color: $secondary !important;
         }
     }
-    &.is-light a.nav-item.is-drop:hover a {
+    &.is-light a.navbar-item.is-drop:hover a {
         color: $secondary !important;
     }
     &.is-light a.button, &.is-warning a.button {
@@ -73,7 +73,7 @@ Hero styles
     }
 }
 
-.nav-item.is-drop  {
+.navbar-item.is-drop  {
     color: #7a7a7a;
     &:hover {
         color: $secondary !important;

--- a/source/scss/_navbar.scss
+++ b/source/scss/_navbar.scss
@@ -4,7 +4,6 @@ Navbar
 
 .navbar-wrapper.navbar-sticky {
     width: 100%;
-    height: 4.6rem;
     background: $white;
     position: fixed;
     top: 0;
@@ -21,32 +20,32 @@ Navbar
     box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.12);
 }
 
-.nav-toggle.is-active span {
+.navbar-toggle.is-active span {
     background-color: $secondary;
 }
 
-.nav {
+.navbar {
     .container {
         min-height: 4rem;
     }
     .container.big {
         min-height: 4.6rem;
     }
-    .nav-item.is-tab:hover {
+    .navbar-item.is-tab:hover {
         border-bottom-color: $secondary;
     }
-    .nav-item.is-tab.is-active {
+    .navbar-item.is-tab.is-active {
         border-bottom: 3px solid $secondary !important;
         color: $secondary !important;
     }
-    .nav-item.is-tab.nav-icon.is-active {
+    .navbar-item.is-tab.navbar-icon.is-active {
         border-bottom: 3px solid transparent !important;
         i {
             color: $primary !important;
             font-size: 20px;
         }
     }
-    .nav-toggle {
+    .navbar-toggle {
         width: 64px;
         height: 64px;
     }

--- a/source/scss/_responsive.scss
+++ b/source/scss/_responsive.scss
@@ -4,25 +4,25 @@ Responsive Styles
 
 @media (max-width: 767px) {
 
-    div.nav-item.is-drop  {
+    div.navbar-item.is-drop  {
         border-top: 1px solid transparent !important;
     }
-    div.nav-item.is-drop a {
+    div.navbar-item.is-drop a {
         padding-left: 4px !important;
     }
-    .nav-item.is-tab {
+    .navbar-item.is-tab {
         padding-top: 8px;
         padding-bottom: 8px;
     }
-    .nav .nav-item.is-tab.is-active {
+    .nav .navbar-item.is-tab.is-active {
         border-bottom: none !important;
         color: $secondary;
     }
-    .nav-item.nav-inner {
+    .navbar-item.navbar-inner {
         padding-top: 15px !important;
         padding-bottom: 15px !important;
     }
-    .nav-item.nav-inner-xs {
+    .navbar-item.navbar-inner-xs {
         padding-top: 6px !important;
         padding-bottom: 6px !important;
     }

--- a/static/js/fresh.js
+++ b/static/js/fresh.js
@@ -2,8 +2,8 @@ $(document).ready(function(){
 
     // The following code is based off a toggle menu by @Bradcomp
     (function() {
-        var burger = document.querySelector('.nav-toggle');
-        var menu = document.querySelector('.nav-menu');
+        var burger = document.querySelector('.navbar-toggle');
+        var menu = document.querySelector('.navbar-menu');
         burger.addEventListener('click', function() {
             burger.classList.toggle('is-active');
             menu.classList.toggle('is-active');


### PR DESCRIPTION
This pull request fixes #5 by replacing the [deprecated "nav" Bulma class](https://bulma.io/documentation/components/nav/) by its successor class, "[navbar](https://bulma.io/documentation/components/navbar/)".

- Renames all "nav" classes with the "navbar" prefix.
- Replaces all references to the old classes for the new ones.
- Removes some now unnecessary styles such as the fixed height.
- Updates old class suffixes ("-left" and "-right") to the new ones ("-start" and "-end").
- Fixes caret alignment and displacement issues in the dropdown feature.

I have tested the theme locally to make sure that it matches the [screenshot in the Hugo portfolio](https://themes.gohugo.io/hugo-fresh/).