### PR TITLE
Allow single pages

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -15,8 +15,15 @@
 
     {{ partial "single/single.html" . }}
 
-    {{ partial "javascript.html" . }}
+    <!-- Back To Top Button -->
+    <div id="backtotop"><a href="#"></a></div>
+
+    {{ if .Params.sidebar }}
+    {{ partial "single/sidebar.html" . }}
+    {{ end }}
 
     {{ end }}
+
+    {{ partial "javascript.html" . }}
   </body>
 </html>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="{{ .Site.LanguageCode }}">
+  <head>
+    {{ partial "meta.html" . }}
+    <title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>
+    {{ partial "css.html" . }}
+  </head>
+  <body>
+    <!-- Preloader -->
+    <div id="preloader">
+      <div id="status"></div>
+    </div>
+
+    {{ block "main" . }}
+
+    {{ partial "single/single.html" . }}
+
+    {{ partial "javascript.html" . }}
+
+    {{ end }}
+  </body>
+</html>

--- a/layouts/partials/navbar-clone.html
+++ b/layouts/partials/navbar-clone.html
@@ -1,5 +1,8 @@
 {{- $navbar         := .Site.Params.navbar }}
 {{- $sidebarVisible := .Site.Params.sidebar }}
+{{ if .Params.sidebar }}
+{{ $sidebarVisible = .Params.sidebar }}
+{{ end }}
 {{- $navbarLogo     := .Site.Params.navbarlogo }}
 <nav id="navbar-clone" class="navbar is-fresh is-transparent" role="navigation" aria-label="main navigation">
   <div class="container">

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,5 +1,8 @@
 {{- $navbar         := .Site.Params.navbar }}
 {{- $sidebarVisible := .Site.Params.sidebar }}
+{{ if .Params.sidebar }}
+{{ $sidebarVisible = .Params.sidebar }}
+{{ end }}
 {{- $navbarLogo     := .Site.Params.navbarlogo }}
 <nav class="navbar is-fresh is-transparent no-shadow" role="navigation" aria-label="main navigation">
   <div class="container">

--- a/layouts/partials/single/content.html
+++ b/layouts/partials/single/content.html
@@ -3,7 +3,7 @@
     <div class="columns">
       <div class="column is-centered-tablet-portrait">
         <h1 class="title section-title">{{ .Title }}</h1>
-        <h3 class="subtitle is-5 is-muted">{{ .Params.Subtitle }}</h3>
+        <h5 class="subtitle is-5 is-muted">{{ .Params.Subtitle }}</h5>
         <div class="divider"></div>
       </div>
     </div>

--- a/layouts/partials/single/content.html
+++ b/layouts/partials/single/content.html
@@ -1,0 +1,12 @@
+<section class="section is-medium">
+  <div class="container">
+    <div class="columns">
+      <div class="column is-centered-tablet-portrait">
+        <h1 class="title section-title">{{ .Title }}</h1>
+        <h3 class="subtitle is-5 is-muted">{{ .Params.Subtitle }}</h3>
+        <div class="divider"></div>
+      </div>
+    </div>
+    {{ .Content }}
+  </div>
+</section>

--- a/layouts/partials/single/sidebar.html
+++ b/layouts/partials/single/sidebar.html
@@ -1,0 +1,20 @@
+{{- $logo     := .Params.sidebarlogo }}
+<div class="sidebar">
+  <div class="sidebar-header">
+    <img src="{{ printf "/images/logos/%s.svg" $logo | relURL }}">
+    <a class="sidebar-close" href="javascript:void(0);">
+      <i data-feather="x"></i>
+    </a>
+  </div>
+  <div class="inner">
+    <ul class="sidebar-menu">
+      {{ range where .Site.RegularPages "Section" (strings.TrimSuffix "/" .Dir) }}
+      <li>
+        <a href="{{ .URL }}">
+          {{ .Title }}
+        </a>
+      </li>
+      {{ end }}
+    </ul>
+  </div>
+</div>

--- a/layouts/partials/single/single.html
+++ b/layouts/partials/single/single.html
@@ -1,0 +1,3 @@
+{{ partial "navbar.html" . }}
+{{ partial "navbar-clone.html" . }}
+{{ partial "single/content.html" . }}

--- a/layouts/shortcodes/subtitle1.html
+++ b/layouts/shortcodes/subtitle1.html
@@ -1,0 +1,1 @@
+<h1 class="subtitle is-1">{{ .Get 0 }}</h1>

--- a/layouts/shortcodes/subtitle2.html
+++ b/layouts/shortcodes/subtitle2.html
@@ -1,1 +1,1 @@
-<h1 class="subtitle is-2">{{ .Get 0 }}</h1>
+<h2 class="subtitle is-2">{{ .Get 0 }}</h2>

--- a/layouts/shortcodes/subtitle2.html
+++ b/layouts/shortcodes/subtitle2.html
@@ -1,0 +1,1 @@
+<h1 class="subtitle is-2">{{ .Get 0 }}</h1>

--- a/layouts/shortcodes/subtitle3.html
+++ b/layouts/shortcodes/subtitle3.html
@@ -1,1 +1,1 @@
-<h1 class="subtitle is-3">{{ .Get 0 }}</h1>
+<h3 class="subtitle is-3">{{ .Get 0 }}</h3>

--- a/layouts/shortcodes/subtitle3.html
+++ b/layouts/shortcodes/subtitle3.html
@@ -1,0 +1,1 @@
+<h1 class="subtitle is-3">{{ .Get 0 }}</h1>

--- a/layouts/shortcodes/subtitle4.html
+++ b/layouts/shortcodes/subtitle4.html
@@ -1,1 +1,1 @@
-<h1 class="subtitle is-4">{{ .Get 0 }}</h1>
+<h4 class="subtitle is-4">{{ .Get 0 }}</h4>

--- a/layouts/shortcodes/subtitle4.html
+++ b/layouts/shortcodes/subtitle4.html
@@ -1,0 +1,1 @@
+<h1 class="subtitle is-4">{{ .Get 0 }}</h1>

--- a/layouts/shortcodes/subtitle5.html
+++ b/layouts/shortcodes/subtitle5.html
@@ -1,1 +1,1 @@
-<h1 class="subtitle is-4">{{ .Get 0 }}</h1>
+<h5 class="subtitle is-5">{{ .Get 0 }}</h5>

--- a/layouts/shortcodes/subtitle5.html
+++ b/layouts/shortcodes/subtitle5.html
@@ -1,0 +1,1 @@
+<h1 class="subtitle is-4">{{ .Get 0 }}</h1>

--- a/layouts/shortcodes/subtitle6.html
+++ b/layouts/shortcodes/subtitle6.html
@@ -1,1 +1,1 @@
-<h1 class="subtitle is-6">{{ .Get 0 }}</h1>
+<h6 class="subtitle is-6">{{ .Get 0 }}</h6>

--- a/layouts/shortcodes/subtitle6.html
+++ b/layouts/shortcodes/subtitle6.html
@@ -1,0 +1,1 @@
+<h1 class="subtitle is-6">{{ .Get 0 }}</h1>

--- a/layouts/shortcodes/title1.html
+++ b/layouts/shortcodes/title1.html
@@ -1,0 +1,1 @@
+<h1 class="title is-1">{{ .Get 0 }}</h1>

--- a/layouts/shortcodes/title2.html
+++ b/layouts/shortcodes/title2.html
@@ -1,1 +1,1 @@
-<h1 class="title is-2">{{ .Get 0 }}</h1>
+<h2 class="title is-2">{{ .Get 0 }}</h2>

--- a/layouts/shortcodes/title2.html
+++ b/layouts/shortcodes/title2.html
@@ -1,0 +1,1 @@
+<h1 class="title is-2">{{ .Get 0 }}</h1>

--- a/layouts/shortcodes/title3.html
+++ b/layouts/shortcodes/title3.html
@@ -1,1 +1,1 @@
-<h1 class="title is-3">{{ .Get 0 }}</h1>
+<h3 class="title is-3">{{ .Get 0 }}</h3>

--- a/layouts/shortcodes/title3.html
+++ b/layouts/shortcodes/title3.html
@@ -1,0 +1,1 @@
+<h1 class="title is-3">{{ .Get 0 }}</h1>

--- a/layouts/shortcodes/title4.html
+++ b/layouts/shortcodes/title4.html
@@ -1,1 +1,1 @@
-<h1 class="title is-4">{{ .Get 0 }}</h1>
+<h4 class="title is-4">{{ .Get 0 }}</h4>

--- a/layouts/shortcodes/title4.html
+++ b/layouts/shortcodes/title4.html
@@ -1,0 +1,1 @@
+<h1 class="title is-4">{{ .Get 0 }}</h1>

--- a/layouts/shortcodes/title5.html
+++ b/layouts/shortcodes/title5.html
@@ -1,1 +1,1 @@
-<h1 class="title is-5">{{ .Get 0 }}</h1>
+<h5 class="title is-5">{{ .Get 0 }}</h5>

--- a/layouts/shortcodes/title5.html
+++ b/layouts/shortcodes/title5.html
@@ -1,0 +1,1 @@
+<h1 class="title is-5">{{ .Get 0 }}</h1>

--- a/layouts/shortcodes/title6.html
+++ b/layouts/shortcodes/title6.html
@@ -1,1 +1,1 @@
-<h1 class="title is-6">{{ .Get 0 }}</h1>
+<h6 class="title is-6">{{ .Get 0 }}</h6>

--- a/layouts/shortcodes/title6.html
+++ b/layouts/shortcodes/title6.html
@@ -1,0 +1,1 @@
+<h1 class="title is-6">{{ .Get 0 }}</h1>


### PR DESCRIPTION
This will add a very basic/simple single page to the theme:
![geist_1542356277259](https://user-images.githubusercontent.com/10229883/48606838-a352d300-e980-11e8-97aa-24374630bd86.gif)

The layout is pretty easy.
It will just display a "title" which and below the content of the markdown files.

**How to:**
Just create pages (markdown files) in the `content` directory.
The pages could have the addional parameters:
```
sidebar: true # Display the sidebar (see more below)
sidebarlogo: fresh-white-alt # Display the sidebar logo 
```
For pages which are "multipaged" (see more below) you should put your pages in a subdir of `content` (e.g. `content/tutorial/1.md`). When the `sidebar` param is set to true it will go over these subdir (`tutorial`)  and populate the sidebar according to the content.

**Multipaged:**
The single page could also be some kind of "tutorial" or "documentation" which ist most of the time a "multipaged". Because of this I've added the ability to add a sidebar to the singepage for easier navigation.

I've also added some "title/subtitle" shortcodes because bulma removes all html h1,h2 etc. 

**What is missing currently?**
* The sort order of the sidebar 
* When you visit `[website]/tutorial` nothing will be displayed. I would be cool when it redirects to the first site of this dir...