### PR TITLE
Use real absURL

### DIFF
--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -5,7 +5,7 @@
 {{- $fontFace     := replace .Site.Params.font.name " " "+" }}
 {{- $fontSizes    := delimit .Site.Params.font.sizes "," }}
 {{- $fontUrl      := printf "https://fonts.googleapis.com/css?family=%s:%s" $fontFace $fontSizes }}
-<link rel="icon" type="image/png" href="{{ "/images/favicon.png" | absURL }}" />
+<link rel="icon" type="image/png" href="{{ "images/favicon.png" | absURL }}" />
 <link href="{{ $fontUrl }}" rel="stylesheet">
 {{- if $inServerMode }}
 {{- $css := resources.Get $sass | toCSS $cssOpts }}
@@ -14,4 +14,4 @@
 {{- $css := resources.Get $sass | toCSS $cssOpts | minify | fingerprint }}
 <link rel="stylesheet" type="text/css" href="{{ $css.RelPermalink }}" integrity="{{ $css.Data.Integrity }}">
 {{- end }}
-<link rel="stylesheet" type="text/css" href="{{ "/css/icons.css" | absURL }}">
+<link rel="stylesheet" type="text/css" href="{{ "css/icons.css" | absURL }}">


### PR DESCRIPTION
I've just removed the leading slash because otherwise the `absURL` get translated wrong in some scenarios...

Imagine you have a baseUrl of `stuff.com/static/website`.
When we use the current code it leads to `stuff.com/images/favicon.png`.
With this fix it get translated correctly to `stuff.com/static/website/images/favicon.png`....