### PR TITLE
Allow markdown in section2 texts

### DIFF
--- a/layouts/partials/section2.html
+++ b/layouts/partials/section2.html
@@ -23,7 +23,7 @@
               <p>
                 <span class="icon-box-title">{{ .title }}</span>
 
-                <span class="icon-box-text">{{ .text }}</span>
+                <span class="icon-box-text">{{ .text | markdownify }}</span>
               </p>
             </div>
           </div>


### PR DESCRIPTION
The description texts are now plain text, our requirements need links and other markup in there, a simple change