### PR TITLE
Add Stackbit Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,3 +306,9 @@ sidebarlogo: fresh-white-alt # From (static/images/logo/)
 ## Troubleshooting
 
 If you see `error: failed to transform resource: TOCSS: failed to transform "style.sass"` when attempting to run your `hugo server`, make sure you have the extended version of Hugo installed!
+
+# Stackbit Deploy
+
+This theme is ready to import into Stackbit. This theme can be deployed to Netlify and you can connect any headless CMS including Forestry, NetlifyCMS, DatoCMS or Contentful. 
+
+[![Create with Stackbit](https://assets.stackbit.com/badge/create-with-stackbit.svg)](https://app.stackbit.com/create?theme=https://github.com/StefMa/hugo-fresh)

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -5,8 +5,8 @@ theme: hugo-fresh
 
 params:
   navbarlogo:
-  # Logo (from static/images/logos/___)
-   image: logos/fresh.svg
+  # Logo (from static/)
+   image: images/logos/fresh.svg
    link: /
   font:
     name: "Open Sans"
@@ -105,8 +105,8 @@ params:
       img: 3
   section5: true
   footer:
-    # Logo (from /images/logos/___)
-    logo: fresh-white-alt.svg
+    # Logo (from static/)
+    logo: images/logos/fresh-white-alt.svg
     # Social media links (GitHub, Twitter, etc.). All are optional.
     socialmedia:
     - link: https://github.com/lucperkins/github-fresh

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -5,7 +5,11 @@ theme: hugo-fresh
 
 params:
   navbarlogo:
+<<<<<<< HEAD
+  # Logo (from static/images/logos/___)
+=======
   # Logo (from static/)
+>>>>>>> 1f981218c5741e368adeb3c180d644a183e7df25
    image: images/logos/fresh.svg
    link: /
   font:
@@ -21,14 +25,14 @@ params:
     # Where the main hero button links to
     buttonlink: "#"
     # Hero image (from static/images/___)
-    image: illustrations/worker.svg
+    image: images/illustrations/worker.svg
     # Footer logos (from static/images/logos/clients/___.svg)
     clientlogos:
-    - systek
-    - tribe
-    - kromo
-    - infinite
-    - gutwork
+    - images/logos/clients/systek.svg
+    - images/logos/clients/tribe.svg
+    - images/logos/clients/kromo.svg
+    - images/logos/clients/infinite.svg
+    - images/logos/clients/gutwork.svg
   # Customizable navbar. For a dropdown, add a "sublinks" list.
   navbar:
   - title: Features
@@ -53,17 +57,17 @@ params:
     subtitle: with great responsibility
     tiles:
     - title: App builder
-      icon: mouse-globe
+      icon: images/illustrations/icons/mouse-globe.svg
       text: This is some explanatory text that is on two rows
       url: /
       buttonText: Free trial
     - title: Cloud integration
-      icon: laptop-cloud
+      icon: images/illustrations/icons/laptop-cloud.svg
       text: This is some explanatory text that is on two rows
       url: /
       buttonText: Get started
     - title: Add-ons & plugins
-      icon: plug-cloud
+      icon: images/illustrations/icons/plug-cloud.svg
       text: This is some explanatory text that is on two rows
       url: /
       buttonText: Get started
@@ -74,17 +78,17 @@ params:
     - title: Powerful and unified interface
       text: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin ornare magna eros, eu pellentesque tortor vestibulum ut. Maecenas non massa sem. Etiam finibus odio quis feugiat facilisis.
       # Icon (from /images/illustrations/icons/___.svg)
-      icon: laptop-globe
+      icon: images/illustrations/icons/laptop-globe.svg
     - title: Cross-device synchronisation
       text: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin ornare magna eros, eu pellentesque tortor vestibulum ut. Maecenas non massa sem. Etiam finibus odio quis feugiat facilisis.
-      icon: doc-sync
+      icon: images/illustrations/icons/doc-sync.svg
     - title: Nomad system
       text: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin ornare magna eros, eu pellentesque tortor vestibulum ut. Maecenas non massa sem. Etiam finibus odio quis feugiat facilisis.
-      icon: mobile-feed
+      icon: images/illustrations/icons/mobile-feed.svg
   section3:
     title: One platform
     subtitle: To rule them all
-    image: illustrations/mockups/app-mockup.png
+    image: images/illustrations/mockups/app-mockup.png
     buttonText: Get started
     buttonLink: "#"
   section4:
@@ -94,18 +98,22 @@ params:
     - name: Irma Walters
       quote: Lorem ipsum dolor sit amet, elit deleniti dissentias quo eu, hinc minim appetere te usu, ea case duis scribentur has. Duo te consequat elaboraret, has quando suavitate at.
       job: Accountant
-      img: 1
+      img: images/illustrations/faces/1.png
     - name: John Bradley
       quote: Lorem ipsum dolor sit amet, elit deleniti dissentias quo eu, hinc minim appetere te usu, ea case duis scribentur has. Duo te consequat elaboraret, has quando suavitate at.
       job: Financial Analyst
-      img: 2
+      img: images/illustrations/faces/2.png
     - name: Gary Blackman
       quote: Lorem ipsum dolor sit amet, elit deleniti dissentias quo eu, hinc minim appetere te usu, ea case duis scribentur has. Duo te consequat elaboraret, has quando suavitate at.
       job: HR Manager
-      img: 3
+      img: images/illustrations/faces/3.png
   section5: true
   footer:
+<<<<<<< HEAD
+    # Logo (from /images/logos/___)
+=======
     # Logo (from static/)
+>>>>>>> 1f981218c5741e368adeb3c180d644a183e7df25
     logo: images/logos/fresh-white-alt.svg
     # Social media links (GitHub, Twitter, etc.). All are optional.
     socialmedia:

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -2,6 +2,7 @@ baseURL: http://something-fresh.org/
 languageCode: en-us
 title: Hugo Fresh Theme
 theme: hugo-fresh
+themesDir: "../.."
 
 params:
   navbarlogo:

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -5,13 +5,8 @@ theme: hugo-fresh
 
 params:
   navbarlogo:
-<<<<<<< HEAD
-  # Logo (from static/images/logos/___)
-=======
-  # Logo (from static/)
->>>>>>> 1f981218c5741e368adeb3c180d644a183e7df25
-   image: images/logos/fresh.svg
-   link: /
+    image: images/logos/fresh.svg
+    link: /
   font:
     name: "Open Sans"
     sizes: [400,600]
@@ -109,11 +104,6 @@ params:
       img: images/illustrations/faces/3.png
   section5: true
   footer:
-<<<<<<< HEAD
-    # Logo (from /images/logos/___)
-=======
-    # Logo (from static/)
->>>>>>> 1f981218c5741e368adeb3c180d644a183e7df25
     logo: images/logos/fresh-white-alt.svg
     # Social media links (GitHub, Twitter, etc.). All are optional.
     socialmedia:

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -9,7 +9,7 @@ params:
     link: /
   font:
     name: "Open Sans"
-    sizes: [400,600]
+    sizes: ["400","600"]
   hero:
     # Main hero title
     title: Manage. Deploy.

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -2,7 +2,6 @@ baseURL: http://something-fresh.org/
 languageCode: en-us
 title: Hugo Fresh Theme
 theme: hugo-fresh
-themesDir: "../.."
 
 params:
   navbarlogo:

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -8,7 +8,11 @@
     <div class="columns">
       <div class="column">
         <div class="footer-logo">
+<<<<<<< HEAD
+          <img src="{{ $logo }}">
+=======
           <img src="{{ $logo | relURL }}">
+>>>>>>> 1f981218c5741e368adeb3c180d644a183e7df25
         </div>
       </div>
       {{- range $quickLinks }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -8,7 +8,7 @@
     <div class="columns">
       <div class="column">
         <div class="footer-logo">
-          <img src="{{ printf "/images/logos/%s" $logo | relURL }}">
+          <img src="{{ $logo | relURL }}">
         </div>
       </div>
       {{- range $quickLinks }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -8,11 +8,7 @@
     <div class="columns">
       <div class="column">
         <div class="footer-logo">
-<<<<<<< HEAD
           <img src="{{ $logo }}">
-=======
-          <img src="{{ $logo | relURL }}">
->>>>>>> 1f981218c5741e368adeb3c180d644a183e7df25
         </div>
       </div>
       {{- range $quickLinks }}

--- a/layouts/partials/hero-body.html
+++ b/layouts/partials/hero-body.html
@@ -24,7 +24,7 @@
       </div>
       <div class="column is-5 is-offset-1">
         <figure class="image is-4by3">
-          <img src="{{ printf "/images/%s" $image | relURL }}" alt="Description">
+          <img src="{{ $image }}" alt="Description">
         </figure>
       </div>
     </div>

--- a/layouts/partials/hero-footer.html
+++ b/layouts/partials/hero-footer.html
@@ -4,10 +4,10 @@
   <div class="container">
     <div class="tabs is-centered">
       <ul>
-        {{- range $clientLogos }}
+        {{- range $item :=$clientLogos }}
         <li>
           <a>
-            <img class="partner-logo" src="{{ . }}">
+            <img class="partner-logo" src="{{ $item | relURL }}">
           </a>
         </li>
         {{- end }}

--- a/layouts/partials/hero-footer.html
+++ b/layouts/partials/hero-footer.html
@@ -7,7 +7,7 @@
         {{- range $clientLogos }}
         <li>
           <a>
-            <img class="partner-logo" src="{{ printf "/images/logos/clients/%s.svg" . | relURL }}">
+            <img class="partner-logo" src="{{ . }}">
           </a>
         </li>
         {{- end }}

--- a/layouts/partials/navbar-clone.html
+++ b/layouts/partials/navbar-clone.html
@@ -9,7 +9,7 @@
     <div class="navbar-brand">
       {{- if $navbarLogo}}
       <a class="navbar-item" href="{{ $navbarLogo.link }}">
-        <img src="{{ printf "/images/%s" $navbarLogo.image | relURL }}" alt="" width="112" height="28">
+        <img src="{{ $navbarLogo.image  }}" alt="" width="112" height="28">
       </a>
       {{- end}}
 

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -9,11 +9,7 @@
     <div class="navbar-brand">
       {{- if $navbarLogo}}
       <a class="navbar-item" href="{{ $navbarLogo.link }}">
-<<<<<<< HEAD
         <img src="{{ $navbarLogo.image }}" alt="" width="112" height="28">
-=======
-        <img src="{{ $navbarLogo.image | relURL }}" alt="" width="112" height="28">
->>>>>>> 1f981218c5741e368adeb3c180d644a183e7df25
       </a>
       {{- end}}
 

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -9,7 +9,11 @@
     <div class="navbar-brand">
       {{- if $navbarLogo}}
       <a class="navbar-item" href="{{ $navbarLogo.link }}">
+<<<<<<< HEAD
+        <img src="{{ $navbarLogo.image }}" alt="" width="112" height="28">
+=======
         <img src="{{ $navbarLogo.image | relURL }}" alt="" width="112" height="28">
+>>>>>>> 1f981218c5741e368adeb3c180d644a183e7df25
       </a>
       {{- end}}
 

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -9,7 +9,7 @@
     <div class="navbar-brand">
       {{- if $navbarLogo}}
       <a class="navbar-item" href="{{ $navbarLogo.link }}">
-        <img src="{{ printf "/images/%s" $navbarLogo.image | relURL }}" alt="" width="112" height="28">
+        <img src="{{ $navbarLogo.image | relURL }}" alt="" width="112" height="28">
       </a>
       {{- end}}
 

--- a/layouts/partials/section1.html
+++ b/layouts/partials/section1.html
@@ -19,7 +19,7 @@
               <h4>{{ .title }}</h4>
             </div>
             <div class="card-icon">
-                <img src="{{ printf "/images/illustrations/icons/%s.svg" .icon | relURL }}">
+                <img src="{{ .icon }}">
             </div>
             <div class="card-text">
                 <p>{{ .text }}</p>

--- a/layouts/partials/section2.html
+++ b/layouts/partials/section2.html
@@ -15,7 +15,7 @@
         <article class="media icon-box">
           <figure class="media-left">
             <p class="image">
-              <img src="{{ printf "/images/illustrations/icons/%s.svg" .icon | relURL }}">
+              <img src="{{  .icon }}">
             </p>
           </figure>
           <div class="media-content mt-50">

--- a/layouts/partials/section3.html
+++ b/layouts/partials/section3.html
@@ -9,7 +9,7 @@
     <div class="columns">
       <div class="column is-10 is-offset-1">
         <div class="has-text-centered">
-          <img class="pushed-image" src="{{ printf "/images/%s" $image | relURL }}">
+          <img class="pushed-image" src="{{  $image  }}">
         </div>
       </div>
     </div>

--- a/layouts/partials/section4.html
+++ b/layouts/partials/section4.html
@@ -21,7 +21,7 @@
               {{ .quote }}
             </blockquote>
             <div class="author">
-              <img src="{{ printf "/images/illustrations/faces/%s.png" (string .img) | relURL }}" alt=""/>
+              <img src="{{ .img }}" alt=""/>
               <h5>{{ .name }}</h5>
               <span>{{ .job }}</span>
             </div>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -3,7 +3,7 @@
 {{- $sections := index $sidebar "sections" }}
 <div class="sidebar">
   <div class="sidebar-header">
-    <img src="{{ printf "/images/logos/%s.svg" $logo | relURL }}">
+    <img src="{{ $logo }}">
     <a class="sidebar-close" href="javascript:void(0);">
       <i data-feather="x"></i>
     </a>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[build]
+  publish = "exampleSite/public"
+  command = "cd exampleSite && hugo --gc --themesDir ../.."
+
+[build.environment]
+  HUGO_VERSION = "0.51"
+  HUGO_THEME = "repo"
+  HUGO_BASEURL = "/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,0 @@
-[build]
-  publish = "exampleSite/public"
-  command = "cd exampleSite && hugo --gc --themesDir ../.."
-
-[build.environment]
-  HUGO_VERSION = "0.51"
-  HUGO_THEME = "repo"
-  HUGO_BASEURL = "/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[build.environment]
+  HUGO_VERSION = "0.55.6"
+  HUGO_THEME = "repo"
+  HUGO_BASEURL = "/" 

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -54,7 +54,7 @@ models:
                 name: sizes
                 label: Font weights
                 items:
-                  type: number
+                  type: string
           - type: object
             name: hero
             label: Hero Section

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -3,7 +3,7 @@ ssgName: custom
 publishDir: exampleSite/public
 buildCommand: cd exampleSite && hugo --gc --baseURL "/" --themesDir ../.. && cd ..
 uploadDir: images
-staticDir: exampleSite/static
+staticDir: static
 pagesDir: exampleSite/content
 dataDir: exampleSite
 models:

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -10,7 +10,7 @@ models:
   config:
     type: data
     label: Config
-    file: config.toml
+    file: config.yaml
     fields:
       - type: string
         name: title

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -1,0 +1,333 @@
+stackbitVersion: ~0.2.0
+ssgName: custom
+publishDir: exampleSite/public
+buildCommand: cd exampleSite && hugo --gc --baseURL "/" --themesDir ../.. && cd ..
+uploadDir: images
+staticDir: exampleSite/static
+pagesDir: exampleSite/content
+dataDir: exampleSite
+models:
+  config:
+    type: data
+    label: Config
+    file: config.toml
+    fields:
+      - type: string
+        name: title
+        label: Title
+        required: true
+      - type: string
+        name: baseURL
+        label: Base baseURL
+        description: Hostname (and path)  to the root
+      - type: string
+        name: languageCode
+        label: Language Code "en"
+      - type: string
+        name: theme
+        label: Theme Name 
+      - type: string
+        name: themesDir
+        label: Themes Folder Path
+      - type: object
+        name: params
+        label: Site Parameters
+        fields:
+          - type: object
+            name: navbarlogo
+            label: Navbar Logo
+            fields:
+              - type: image
+                name: image
+                label: Logo image
+              - type: string
+                name: link
+                label: Logo link
+          - type: object
+            name: font
+            label: Font family
+            fields:
+              - type: string
+                name: name
+                label: Font family name
+              - type: list
+                name: sizes
+                label: Font weights
+                items:
+                  type: number
+          - type: object
+            name: hero
+            label: Hero Section
+            fields:
+              - type: string
+                name: title
+                label: Title
+              - type: string
+                name: subtitle
+                label: Subtitle
+              - type: string
+                name: buttontext
+                label: Button Text
+              - type: string
+                name: buttonlink
+                label: Button Link
+              - type: image
+                name: image
+                label: Image
+              - type: list
+                name: clientlogos
+                label: Client Logos
+                items:
+                  type: string
+          - type: list
+            name: navbar
+            label: Navbar
+            items:
+              type: object
+              fields:
+                - type: string
+                  name: title
+                  label: Title
+                  required: true
+                - type: string
+                  name: url
+                  label: URL
+                - type: list
+                  name: sublinks
+                  label: Dropdown Sublinks
+                  items:
+                    type: object
+                    fields:
+                      - type: string
+                        name: title
+                        label: Title
+                        required: true
+                      - type: string
+                        name: url
+                        label: URL
+                - type: boolean
+                  name: button
+                  label: Button
+          - type: object
+            name: section1
+            label: First Section
+            fields:
+              - type: string
+                name: title
+                label: Title
+              - type: string
+                name: subtitle
+                label: Subtitle
+              - type: list
+                name: tiles
+                label: Tiles
+                items:
+                  type: object
+                  fields:
+                    - type: string
+                      name: title
+                      label: Title
+                      required: true
+                    - type: string
+                      name: icon
+                      label: Icon
+                    - type: text
+                      name: text
+                      label: Text
+                    - type: string
+                      name: url
+                      label: URL
+                    - type: string
+                      name: buttonText
+                      label: Button Text
+          - type: object
+            name: section2
+            label: Second Section
+            fields:
+              - type: string
+                name: title
+                label: Title
+              - type: string
+                name: subtitle
+                label: Subtitle
+              - type: list
+                name: features
+                label: Features
+                items:
+                  type: object
+                  fields:
+                    - type: string
+                      name: title
+                      label: Title
+                      required: true
+                    - type: text
+                      name: text
+                      label: Text
+                    - type: string
+                      name: icon
+                      label: Icon
+          - type: object
+            name: section3
+            label: Third Section
+            fields: 
+              - type: string
+                name: title
+                label: Title
+              - type: string
+                name: subtitle
+                label: Subtitle
+              - type: image
+                name: image
+                label: Image
+              - type: string
+                name: buttonText
+                label: Button Text
+              - type: string
+                name: buttonLink
+                label: Button Link
+          - type: object
+            name: section4
+            label: Forth Section
+            fields:
+              - type: string
+                name: title
+                label: Title
+              - type: string
+                name: subtitle
+                label: Subtitle
+              - type: list
+                name: clients
+                label: Clients
+                items:
+                  type: object
+                  fields:
+                    - type: string
+                      name: name
+                      label: Client Name
+                    - type: text
+                      name: quote
+                      label: Quote
+                    - type: string
+                      name: job
+                      label: Job
+                    - type: number
+                      name: img
+                      label: Image
+          - type: boolean
+            name: section5
+            label: Fifth Section 
+          - type: object
+            name: footer
+            label: Footer
+            fields:
+              - type: image
+                name: logo
+                label: Footer Logo
+              - type: list
+                name: socialmedia
+                label: Social Media
+                items:
+                  type: object
+                  fields: 
+                    - type: string
+                      name: link
+                      label: Link
+                    - type: string
+                      name: icon
+                      label: Icon
+              - type: boolean
+                name: bulmalogo
+                label: Bulma Logo
+              - type: object
+                name: quicklinks
+                label: Quick Links
+                fields:
+                  - type: object
+                    name: column1
+                    label: First Column
+                    fields:
+                      - type: string
+                        name: title
+                        label: Title
+                      - type: list
+                        name: links
+                        label: Links
+                        items:
+                          type: object
+                          fields:
+                            - type: string
+                              name: text
+                              label: Text
+                            - type: string
+                              name: link
+                              label: Link
+                  - type: object
+                    name: column2
+                    label: Second Column
+                    fields:
+                      - type: string
+                        name: title
+                        label: Title
+                      - type: list
+                        name: links
+                        label: Links
+                        items:
+                          type: object
+                          fields:
+                            - type: string
+                              name: text
+                              label: Text
+                            - type: string
+                              name: link
+                              label: Link
+                  - type: object
+                    name: column3
+                    label: Third Column
+                    fields: 
+                      - type: string
+                        name: title
+                        label: Title
+                      - type: list
+                        name: links
+                        label: Links
+                        items:
+                          type: object
+                          fields:
+                            - type: string
+                              name: text
+                              label: Text
+                            - type: string
+                              name: link
+                              label: Link
+  basicpage:
+    type: page
+    label: Basic Page
+    match: "*.md"
+    fields:
+      - type: string
+        name: title
+        label: Title
+        required: true
+  blog:
+    type: page
+    label: Blog
+    folder: blog
+    fields:
+      - type: string
+        name: title
+        label: Title
+      - type: boolean
+        name: sidebar
+        label: SideBar
+      - type: string
+        name: sidebarlogo
+        label: Sidebar Logo
+
+
+
+
+
+
+
+
+

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -78,7 +78,7 @@ models:
                 name: clientlogos
                 label: Client Logos
                 items:
-                  type: string
+                  type: image
           - type: list
             name: navbar
             label: Navbar
@@ -128,7 +128,7 @@ models:
                       name: title
                       label: Title
                       required: true
-                    - type: string
+                    - type: image
                       name: icon
                       label: Icon
                     - type: string
@@ -163,7 +163,7 @@ models:
                     - type: string
                       name: text
                       label: Text
-                    - type: string
+                    - type: image
                       name: icon
                       label: Icon
           - type: object
@@ -210,7 +210,7 @@ models:
                     - type: string
                       name: job
                       label: Job
-                    - type: number
+                    - type: image
                       name: img
                       label: Image
           - type: boolean

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -131,7 +131,7 @@ models:
                     - type: string
                       name: icon
                       label: Icon
-                    - type: text
+                    - type: string
                       name: text
                       label: Text
                     - type: string
@@ -160,7 +160,7 @@ models:
                       name: title
                       label: Title
                       required: true
-                    - type: text
+                    - type: string
                       name: text
                       label: Text
                     - type: string
@@ -204,7 +204,7 @@ models:
                     - type: string
                       name: name
                       label: Client Name
-                    - type: text
+                    - type: string
                       name: quote
                       label: Quote
                     - type: string


### PR DESCRIPTION
This pull request add's Stackbit to this Hugo theme. It add's the stackbit.yaml file which makes this theme work with several headless CMS automatically (including Forestry, NetlifyCMS, DatoCMS & Contentful) and it deploys the site to Netlify in 1 click.

You can try it out: https://app.stackbit.com/create?theme=https://github.com/stackbithq/aether (note the "create with stackbit" button in the readme will import the theme from your repo so until the PR is merged it wont work)

I think this is really valuable and is a very low impact addition on your existing theme structure. Pretty much just the stackbit.yaml file. If you have questions or feedback I'm happy to discuss.

Darko