### PR TITLE
Added the ability to use google analytics using Hugo's internal templ…

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -2,6 +2,7 @@ baseURL: http://something-fresh.org/
 languageCode: en-us
 title: Hugo Fresh Theme
 theme: hugo-fresh
+googleAnalytics: #Put in your tracking code without quotes like this: UA-XXXXXX...
 
 params:
   navbarlogo:

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -1,3 +1,4 @@
+{{ template "_internal/google_analytics_async.html" . }}
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta http-equiv="x-ua-compatible" content="ie=edge">

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,3 +1,4 @@
+{{ template "_internal/google_analytics_async.html" . }}
 {{- $navbar         := .Site.Params.navbar }}
 {{- $sidebarVisible := .Site.Params.sidebar }}
 {{ if .Params.sidebar }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,4 +1,3 @@
-{{ template "_internal/google_analytics_async.html" . }}
 {{- $navbar         := .Site.Params.navbar }}
 {{- $sidebarVisible := .Site.Params.sidebar }}
 {{ if .Params.sidebar }}


### PR DESCRIPTION
…ate. Added a sample config and instructions to config.yaml for the example site and added in a link for the google analytics internal template for the navbar partial per https://gohugo.io/templates/internal/