### PR TITLE
Add footer to AGB single page

### DIFF
--- a/exampleSite/content/agb.md
+++ b/exampleSite/content/agb.md
@@ -1,5 +1,6 @@
 ---
 title: AGB
+include_footer: true
 ---
 
 {{% title3 "§1 Lorem" %}}


### PR DESCRIPTION
This will add the footer (as an example) to the AGB site.
See also #79 and #74 

Thanks for the feature @nathanbiller!

![Geist_1570183858392](https://user-images.githubusercontent.com/10229883/66199957-32073600-e6a0-11e9-95f1-f70eb32d5023.gif)
