### PR TITLE
Update default class for ordered and unordered lists

### DIFF
--- a/assets/bulma/sass/base/minireset.sass
+++ b/assets/bulma/sass/base/minireset.sass
@@ -38,8 +38,20 @@ h6
 
 // List
 ul
-  list-style: none
+  list-style: disc outside
+  padding: 5px
+  margin-left: 40px
 
+ul.link-list
+  list-style: none outside
+  padding: 0px
+  margin-left: 0px
+
+ol
+  list-style: decimal outside
+  padding: 5px
+  margin-left: 40px
+  
 // Form
 button,
 input,


### PR DESCRIPTION
Because the original theme only had a front-page and no single pages the global class for lists was set to display none for the footer.

With the addition of single pages, standard markdown was setting UL and OL tags but nothing was being displayed. I'm no CSS expert, but I played around until I got something that seemed to look pretty good. And then I preserved the formatting by setting the "link-list" class that the footer used to keep the original settings.

Now using markdown files for ordered and unordered lists works as expected.