### PR TITLE
Fix example site config

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -5,8 +5,8 @@ theme: hugo-fresh
 googleAnalytics: #Put in your tracking code without quotes like this: UA-XXXXXX...
 #Disables warningss
 disableKinds:
- -taxonomy
- -taxonomyTerm
+- taxonomy
+- taxonomyTerm
 
 
 params:


### PR DESCRIPTION
The example site config is currently broken due to invalid YAML.