### PR TITLE
Update exampleSite config to allow raw html

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -2,22 +2,25 @@ baseURL: http://something-fresh.org/
 languageCode: en-us
 title: Hugo Fresh Theme
 theme: hugo-fresh
-googleAnalytics: #Put in your tracking code without quotes like this: UA-XXXXXX...
-#Disables warningss
+googleAnalytics: # Put in your tracking code without quotes like this: UA-XXXXXX...
+# Disables warnings
 disableKinds:
- -taxonomy
- -taxonomyTerm
-
+- taxonomy
+- taxonomyTerm
+markup:
+  goldmark:
+    renderer:
+      unsafe: true # Allows you to write raw html in your md files
 
 params:
- # Open graph allows easy social sharing. If you don't want it you can set it to false or just delete the variable
+  # Open graph allows easy social sharing. If you don't want it you can set it to false or just delete the variable
   openGraph: true
   # Used as meta data; describe your site to make Google Bots happy 
   description: 
   navbarlogo:
   # Logo (from static/images/logos/___)
-   image: logos/fresh.svg
-   link: /
+    image: logos/fresh.svg
+    link: /
   font:
     name: "Open Sans"
     sizes: [400,600]


### PR DESCRIPTION
Based on [Hugo 0.60.0 release](https://gohugo.io/news/0.60.0-relnotes/) the Markdown library has been updated to Goldmark.

And as the release note says:
> if you have lots of inline HTML in your Markdown files, you may have to enable the unsafe mode

![Screenshot from 2019-12-04 19-23-20](https://user-images.githubusercontent.com/1302282/70138613-9445dc80-16cb-11ea-8c84-a802f4c2dd85.png)

So I added the **unsafe** flag to allow raw html in md files.


This fix the `agb.md` file in the `exampleSite` (there was an issue with shortcodes and `<br>` tags rendered as html comments: `raw html omitted`).

----

Also closes #97 