### PR TITLE
Parameterize font in sass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
 
       - run:
           name: Create site
-          command: hugo new site my-site
+          command: /usr/local/bin/hugo new site my-site
 
       - run:
           name: Clone the theme from the PR
@@ -70,7 +70,7 @@ jobs:
       - run:
           name: Create hugo site
           working_directory: my-site
-          command: hugo
+          command: /usr/local/bin/hugo
 
       - run:
           name: Create now.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
           name: Install hugo
           command: |
             apk add wget
-            wget -q https://github.com/gohugoio/hugo/releases/download/v0.63.2/hugo_0.63.2_Linux-64bit.tar.gz
+            wget -q https://github.com/gohugoio/hugo/releases/download/v0.63.2/hugo_extended_0.63.2_Linux-64bit.tar.gz
             apk add tar
             tar xzf hugo_0.63.2_Linux-64bit.tar.gz
             chmod a+x hugo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
             apk add wget
             wget -q https://github.com/gohugoio/hugo/releases/download/v0.63.2/hugo_extended_0.63.2_Linux-64bit.tar.gz
             apk add tar
-            tar xzf hugo_0.63.2_Linux-64bit.tar.gz
+            tar xzf hugo_extended_0.63.2_Linux-64bit.tar.gz
             chmod a+x hugo
             mv hugo /usr/local/bin/hugo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,9 @@ jobs:
           name: Install hugo
           command: |
             apk add wget
-            wget -q https://github.com/gohugoio/hugo/releases/download/v0.58.3/hugo_0.58.3_Linux-64bit.tar.gz
+            wget -q https://github.com/gohugoio/hugo/releases/download/v0.63.2/hugo_0.63.2_Linux-64bit.tar.gz
             apk add tar
-            tar xzf hugo_0.58.3_Linux-64bit.tar.gz
+            tar xzf hugo_0.63.2_Linux-64bit.tar.gz
             chmod a+x hugo
             mv hugo /usr/local/bin/hugo
 

--- a/assets/fresh/partials/_buttons.scss
+++ b/assets/fresh/partials/_buttons.scss
@@ -8,7 +8,7 @@ Classes to change the feel of bulma buttons
     cursor: pointer;
     transition: all 0.5s;
     &.cta {
-        font-family: Sfont-stack;
+        font-family: $font-stack;
         font-size: 1rem;
         font-weight: 600;
         padding: 26px 40px 26px 40px;
@@ -29,7 +29,7 @@ Classes to change the feel of bulma buttons
     &.signup-button {
         font-size: .9rem;
         font-weight: 600;
-        font-family: Sfont-stack;
+        font-family: $font-stack;
         padding: 24px 26px;
         width: 130px;
     }

--- a/assets/fresh/partials/_buttons.scss
+++ b/assets/fresh/partials/_buttons.scss
@@ -8,7 +8,7 @@ Classes to change the feel of bulma buttons
     cursor: pointer;
     transition: all 0.5s;
     &.cta {
-        font-family: 'Open Sans', sans-serif;
+        font-family: Sfont-stack;
         font-size: 1rem;
         font-weight: 600;
         padding: 26px 40px 26px 40px;
@@ -29,7 +29,7 @@ Classes to change the feel of bulma buttons
     &.signup-button {
         font-size: .9rem;
         font-weight: 600;
-        font-family: 'Open Sans', sans-serif;
+        font-family: Sfont-stack;
         padding: 24px 26px;
         width: 130px;
     }

--- a/assets/fresh/partials/_cards.scss
+++ b/assets/fresh/partials/_cards.scss
@@ -12,7 +12,7 @@ Cards and Card content styles
     border-radius: 3px;
     margin: 0 auto;
     .card-title h4 {
-        font-family: Sfont-stack;
+        font-family: $font-stack;
         padding-top: 25px;
         font-size: 1.2rem;
         font-weight: 600;

--- a/assets/fresh/partials/_cards.scss
+++ b/assets/fresh/partials/_cards.scss
@@ -12,7 +12,7 @@ Cards and Card content styles
     border-radius: 3px;
     margin: 0 auto;
     .card-title h4 {
-        font-family: 'Open Sans', sans-serif;
+        font-family: Sfont-stack;
         padding-top: 25px;
         font-size: 1.2rem;
         font-weight: 600;

--- a/assets/fresh/partials/_hero.scss
+++ b/assets/fresh/partials/_hero.scss
@@ -6,7 +6,7 @@ Hero styles
     padding-top: 6rem;
     padding-bottom: 6rem;
     .title, .subtitle {
-        font-family: Sfont-stack;
+        font-family: $font-stack;
     }
     .title {
         &.is-bold {

--- a/assets/fresh/partials/_hero.scss
+++ b/assets/fresh/partials/_hero.scss
@@ -6,7 +6,7 @@ Hero styles
     padding-top: 6rem;
     padding-bottom: 6rem;
     .title, .subtitle {
-        font-family: 'Open Sans', sans-serif;
+        font-family: Sfont-stack;
     }
     .title {
         &.is-bold {

--- a/assets/fresh/partials/_sections.scss
+++ b/assets/fresh/partials/_sections.scss
@@ -17,7 +17,7 @@ Section Styles
         height: 75vh !important;
     }
     .title, .subtitle {
-        font-family: 'Open Sans', sans-serif;
+        font-family: Sfont-stack;
 
     }
     .subtitle {
@@ -32,7 +32,7 @@ Section Styles
     max-width: 500px;
     margin: 0 auto;
     .title, .subtitle {
-        font-family: 'Open Sans', sans-serif;
+        font-family: Sfont-stack;
 
     }
     .subtitle {

--- a/assets/fresh/partials/_sections.scss
+++ b/assets/fresh/partials/_sections.scss
@@ -17,7 +17,7 @@ Section Styles
         height: 75vh !important;
     }
     .title, .subtitle {
-        font-family: Sfont-stack;
+        font-family: $font-stack;
 
     }
     .subtitle {
@@ -32,7 +32,7 @@ Section Styles
     max-width: 500px;
     margin: 0 auto;
     .title, .subtitle {
-        font-family: Sfont-stack;
+        font-family: $font-stack;
 
     }
     .subtitle {

--- a/assets/fresh/partials/_sidebar.scss
+++ b/assets/fresh/partials/_sidebar.scss
@@ -115,7 +115,7 @@ Sidebar Styles
             max-width: 400px;
             list-style: none;
             list-style-type: none;
-            font-family: Sfont-stack !important;
+            font-family: $font-stack !important;
             li {
                 a {
                     padding: 20px 25px;

--- a/assets/fresh/partials/_sidebar.scss
+++ b/assets/fresh/partials/_sidebar.scss
@@ -115,7 +115,7 @@ Sidebar Styles
             max-width: 400px;
             list-style: none;
             list-style-type: none;
-            font-family: 'Open Sans', sans-serif !important;
+            font-family: Sfont-stack !important;
             li {
                 a {
                     padding: 20px 25px;

--- a/assets/style.sass
+++ b/assets/style.sass
@@ -1,2 +1,8 @@
+// ==========================================================================
+// Parameterized variables
+// ==========================================================================
+
+$font-stack: '{{ .Site.Params.font.name | default "Open Sans" }}', sans-serif
+
 @import "bulma/bulma"
 @import "fresh/core"

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -1,5 +1,6 @@
 {{- $inServerMode := .Site.IsServer }}
 {{- $sass         := "style.sass" }}
+{{- $sassTemplate := "style.$sass" }}
 {{- $cssTarget    := "css/style.css" }}
 {{- $cssOpts      := cond ($inServerMode) (dict "targetPath" $cssTarget "enableSourceMap" true) (dict "targetPath" $cssTarget "outputStyle" "compressed") }}
 {{- $fontName     := .Site.Params.font.name | default "Open Sans" }}
@@ -9,10 +10,10 @@
 <link rel="icon" type="image/png" href="{{ "images/favicon.png" | relURL }}" />
 <link href="{{ $fontUrl }}" rel="stylesheet">
 {{- if $inServerMode }}
-{{- $css := resources.Get $sass | toCSS $cssOpts }}
+{{- $css := resources.Get $sass | resources.ExecuteAsTemplate $sassTemplate . | toCSS $cssOpts }}
 <link rel="stylesheet" type="text/css" href="{{ $css.RelPermalink }}">
 {{- else }}
-{{- $css := resources.Get $sass | toCSS $cssOpts | minify | fingerprint }}
+{{- $css := resources.Get $sass | resources.ExecuteAsTemplate $sassTemplate . | toCSS $cssOpts | minify | fingerprint }}
 <link rel="stylesheet" type="text/css" href="{{ $css.RelPermalink }}" integrity="{{ $css.Data.Integrity }}">
 {{- end }}
 <link rel="stylesheet" type="text/css" href="{{ "css/icons.css" | relURL }}">


### PR DESCRIPTION
Use resources.ExecuteAsTemplate (introduced inn hugo 0.43) to use config variables in SASS.
Unfortunately, only base SASS files can be used as Go template, that's why the variable is defined
in main file instead of partials.

It should fix #46 