### PR TITLE
feat: Allow specifying titles/form action for contact form

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -152,7 +152,12 @@ params:
       quote: Lorem ipsum dolor sit amet, elit deleniti dissentias quo eu, hinc minim appetere te usu, ea case duis scribentur has. Duo te consequat elaboraret, has quando suavitate at.
       job: HR Manager
       img: 3
-  section5: true
+  section5:
+    title: Drop us a line or two
+    subtitle: We'd love to hear from you
+    buttonText: Send Message
+    # action: https://formspree.io/f/<form_id>
+    # method: POST
   footer:
     # Logo (from /images/logos/___)
     logo: fresh-white-alt.svg

--- a/layouts/partials/section5.html
+++ b/layouts/partials/section5.html
@@ -1,27 +1,36 @@
+{{- $section5   := .Site.Params.section5 }}
+{{- if eq $section5 true }}
+{{- $section5 = dict "_" "_" }}
+{{- end }}
+{{- $title      := index $section5 "title" | default "Drop us a line or two "}}
+{{- $subtitle   := index $section5 "subtitle" | default "We'd love to hear from you" }}
+{{- $action     := index $section5 "action" }}
+{{- $method     := index $section5 "method" }}
+{{- $buttonText := index $section5 "buttontext" | default "Send Message" }}
 <section class="section section-light-grey is-medium" id="section5">
   <div class="container">
     <div class="title-wrapper has-text-centered">
-      <h2 class="title is-2 is-spaced">Drop us a line or two </h2>
-      <h3 class="subtitle is-5 is-muted">We'd love to hear from you</h3>
+      <h2 class="title is-2 is-spaced">{{ $title }}</h2>
+      <h3 class="subtitle is-5 is-muted">{{ $subtitle }}</h3>
       <div class="divider is-centered"></div>
     </div>
 
     <div class="content-wrapper">
       <div class="columns">
         <div class="column is-6 is-offset-3">
-          <form>
+          <form{{ with $action }} action="{{ . }}"{{end}}{{ with $method }} method="{{ . }}"{{end}}>
             <div class="columns is-multiline">
               <div class="column is-6">
-                <input class="input is-medium" type="text" placeholder="Enter your name">
+                <input class="input is-medium" name="name" type="text" placeholder="Enter your name">
               </div>
               <div class="column is-6">
-                <input class="input is-medium" type="email" placeholder="Enter your email address">
+                <input class="input is-medium" name="email" type="email" placeholder="Enter your email address">
               </div>
               <div class="column is-12">
-                <textarea class="textarea" rows="10" placeholder="Write someting..."></textarea>
+                <textarea class="textarea" name="message" rows="10" placeholder="Write someting..."></textarea>
               </div>
               <div class="form-footer has-text-centered mt-10">
-                <button class="button cta is-large primary-btn raised is-clear">Send Message</button>
+                <button class="button cta is-large primary-btn raised is-clear">{{ $buttonText }}</button>
               </div>
             </div>
           </form>


### PR DESCRIPTION
Hi @StefMa - a few more handy features if you're happy to merge please! 🙏 . This allows changing the text on the contact us form, and can also be used to quickly integrate with tools like Formspree. I've done it in a hopefully backwards compatible way:

* Text won't change if a user upgrades
* Form action/method isn't enabled by default
* Adding form field names shouldn't cause issues

Thanks!