### PR TITLE
Module docs

### DIFF
--- a/docs/content/module.md
+++ b/docs/content/module.md
@@ -1,0 +1,43 @@
+---
+title: Hugo module
+sidebar: true
+sidebarlogo: fresh-white
+include_footer: false
+---
+
+## Module
+
+The theme is an [hugo modules](https://gohugo.io/hugo-modules/)-theme.
+It is not possible to add this theme as a git submodule anymore.
+
+This provides several benefits for the development of this theme.
+
+### Versioning / stable theme
+
+With modules it is possible to point to any git hash you like. Nevertheless, it is strongly recommended to only use a versionised version of this theme. Checkout the [GitHub Release page](https://github.com/StefMa/hugo-fresh/releases/) for the latest version.
+
+You can run the follwing command to update/change the theme version:
+
+```
+hugo mod get -u github.com/StefMa/hugo-fresh@v[SEMVER_VERSION]
+```
+
+There can be als an `hash` or an `branch` name after the `@`-sign.
+
+### Usage
+
+1. To use the theme you first have to transform your own hugo site to an module. Doing this is possible with the following command:
+
+```
+hugo mod init MODULE_NAME
+```
+
+A typical module name follows the following convention: `domain-name.tld/something`.
+
+2. After that you can declare the hugo module in your config file (yaml example):
+
+```yaml
+module:
+  imports:
+    path: github.com/StefMa/hugo-fresh
+```

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -2,4 +2,6 @@ module github.com/stefma/hugo-fresh/docs
 
 go 1.15
 
-require github.com/StefMa/hugo-fresh v0.0.0-20210215141724-0fa1741f382c // indirect
+replace github.com/StefMa/hugo-fresh => ../
+
+require github.com/StefMa/hugo-fresh v1.0.0 // indirect

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1,2 +1,1 @@
-github.com/StefMa/hugo-fresh v0.0.0-20210215141724-0fa1741f382c h1:QYmEuOnjZddrD7PAaMfOF5QcK6DuuQRANhb7CWY2h4o=
-github.com/StefMa/hugo-fresh v0.0.0-20210215141724-0fa1741f382c/go.mod h1:0kyrjS5vdFJ47D7bPs6JwXTkctiMaQbToeBaOQsw1Tw=
+github.com/jgthms/bulma v0.0.0-20220508134905-3e00a8e6d0d0/go.mod h1:89FLBKXYFKfOKAoDeUT26V0pHGwzr205cMXAEqtAVOI=

--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -4,4 +4,4 @@ go 1.12
 
 replace github.com/StefMa/hugo-fresh => ../
 
-require github.com/StefMa/hugo-fresh v0.0.0-20220303155657-8a3fe0559acf // indirect
+require github.com/StefMa/hugo-fresh v1.0.0 // indirect

--- a/exampleSite/go.sum
+++ b/exampleSite/go.sum
@@ -1,3 +1,1 @@
-github.com/StefMa/hugo-fresh v0.0.0-20220303155657-8a3fe0559acf h1:TO5yCImzeAKlFbIbAvvaN4s1mP45RV4NMoCuXe6zve8=
-github.com/StefMa/hugo-fresh v0.0.0-20220303155657-8a3fe0559acf/go.mod h1:0kyrjS5vdFJ47D7bPs6JwXTkctiMaQbToeBaOQsw1Tw=
 github.com/jgthms/bulma v0.0.0-20220508134905-3e00a8e6d0d0/go.mod h1:89FLBKXYFKfOKAoDeUT26V0pHGwzr205cMXAEqtAVOI=


### PR DESCRIPTION
1. Documents hugo modules a bit.
2. Lets documentation as well as example using v1.0.0 (or latest dev changes as they use `replace`)