### PR TITLE
Add Support for Google Analytics V4 gtag

### DIFF
--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -9,7 +9,7 @@ module:
     path: github.com/StefMa/hugo-fresh
 
 
-googleAnalytics: # Put in your tracking code without quotes like this: UA-XXXXXX...
+googleAnalytics: # Put in your tracking code without quotes like this: UA-XXX for universal tracking or G-XXX analytics v4 tracking
 # Disables warnings
 disableKinds:
 - taxonomy

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -1,4 +1,4 @@
-{{ template "_internal/google_analytics_async.html" . }}
+{{ template "_internal/google_analytics.html" . }}
 {{ if eq .Site.Params.openGraph true }}
 {{ template "_internal/opengraph.html" . }}
 {{ end }}


### PR DESCRIPTION
According to Hugo's documentation (https://gohugo.io/templates/internal/#use-the-google-analytics-template)

This template is not suitable for Google Analytics 4 {{ template "_internal/google_analytics_async.html" . }}

So, this change uses the recommended template that supports both versions.