### PR TITLE
Fix broken links

### DIFF
--- a/docs/content/getstarted.md
+++ b/docs/content/getstarted.md
@@ -7,7 +7,7 @@ include_footer: false
 
 ## The Fresh theme for Hugo
 
-**Fresh** is a theme for the [Hugo](https://gohugo.io) static site generator adapted from the gorgeous, [Bulma](https://bulma.io)-based theme of the same name from [CSS Ninja](https://cssninja.io/themes/fresh). You can find a live demo of the original theme [here](https://cssninjastudio.github.io) and a live demo of the Hugo theme [here](https://hugo-fresh.now.sh/).
+**Fresh** is a theme for the [Hugo](https://gohugo.io) static site generator adapted from the gorgeous, [Bulma](https://bulma.io)-based theme of the same name from [CSS Ninja](https://cssninja.io/product/fresh). You can find a live demo of the original theme [here](https://fresh.cssninja.io) and a live demo of the Hugo theme [here](https://hugo-fresh.now.sh/).
 
 <img src="https://raw.githubusercontent.com/StefMa/hugo-fresh/master/images/screenshot.png" style="margin-left:auto;margin-right:auto;" />
 

--- a/docs/hugo.yml
+++ b/docs/hugo.yml
@@ -19,3 +19,8 @@ params:
   - title: GitHub
     url: https://github.com/StefMa/hugo-fresh
     button: true
+
+markup:
+  goldmark:
+    renderer:
+      unsafe: true # Allows you to write raw html in your md files


### PR DESCRIPTION
This PR addresses two issues:
- it fixes two broken links in the documentation site.
- In the `Markdown syntax guide` of documentation site, display of H<sub>2</sub>0 etc. is broken (section `Other Elements`).  This PR enables raw html for this site to correct this.

This PR is somehow related to #158.