### PR TITLE
Updated documentation to reflect the move to using hugo.toml

### DIFF
--- a/docs/content/getstarted.md
+++ b/docs/content/getstarted.md
@@ -25,7 +25,7 @@ hugo new site my-site && cd my-site
 hugo mod init YOUR_MODULE_NAME
 
 # Remove the default config
-rm config.toml
+rm hugo.toml
 
 # Fetch the example config
 curl -O https://raw.githubusercontent.com/StefMa/hugo-fresh/master/exampleSite/hugo.yaml


### PR DESCRIPTION
From Hugo version 0.110, hugo.toml is used rather than config.toml. 
Updating the getting started documentation to reflect this.