### PR TITLE
Show page contents if page loaded with js disabled

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,6 +4,11 @@
     {{ partial "meta.html" . }}
     <title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>
     {{ partial "css.html" . }}
+    <noscript>
+      <style>
+        #preloader { display: none; }/* show page contents if page loaded with js disabled */
+      </style>
+    </noscript>
   </head>
   <body>
     {{ if ne .Site.Params.preloader false }}


### PR DESCRIPTION
The preloader feature is a simple div overlay hiding the contents of the website, which gets faded out by js with a delay. This might be fine in most cases, but if JS is disabled the preloader div stays in place and prevents the visitors from seeing anything but the menu.

This small noscript section should fix this behaviour.

Might also not work if only thirdparty JS from CDNs is blocked if this feature relies on this code.